### PR TITLE
[Feat] 사용자 위치 정보 수집 구현

### DIFF
--- a/WhatTheTemp/WhatTheTemp/App/Info.plist
+++ b/WhatTheTemp/WhatTheTemp/App/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>현재 위치의 날씨 정보 제공을 위해서는 위치 정보 수집 동의가 필요합니다.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>현재 위치의 날씨 정보 제공을 위해서는 위치 정보 수집 동의가 필요합니다.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/WhatTheTemp/WhatTheTemp/Manager/LocationManager.swift
+++ b/WhatTheTemp/WhatTheTemp/Manager/LocationManager.swift
@@ -1,0 +1,39 @@
+//
+//  LocationManager.swift
+//  WhatTheTemp
+//
+//  Created by EMILY on 08/01/2025.
+//
+
+import CoreLocation
+
+class LocationManager: NSObject {
+    private let locationManager: CLLocationManager = {
+        let manager = CLLocationManager()
+        manager.requestWhenInUseAuthorization()
+        manager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
+        return manager
+    }()
+    
+    var currentLocation: CLLocation? {
+        switch locationManager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:   // 위치 정보 수집 허용 시 : 사용자 위치 반환
+            locationManager.location
+        default:                                          // 위치 정보 수집 불허용/미허용 상태 : 서울시청 위치 반환
+            CLLocation(latitude: 37.5665851, longitude: 126.9782038)
+        }
+    }
+    
+    override init() {
+        super.init()
+        locationManager.delegate = self
+    }
+}
+
+/// 디버깅용
+extension LocationManager: CLLocationManagerDelegate {
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        guard let currentLocation = currentLocation else { return }
+        print(currentLocation)
+    }
+}

--- a/WhatTheTemp/WhatTheTemp/ViewController.swift
+++ b/WhatTheTemp/WhatTheTemp/ViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 
 class ViewController: UIViewController {
     
+    private let locationManager = LocationManager()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
     }


### PR DESCRIPTION
## 📝 요약(Summary)
앱을 실행하자마자 사용자의 위치 정보 수집 권한에 동의를 구하고, 동의 시 사용자의 현위치가 콘솔에 출력되도록 구현했습니다. 거절하더라도 `currentLocation`은 기본값인 서울시청 좌표를 갖습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
![Screen Recording 2025-01-08 at 16 25 14](https://github.com/user-attachments/assets/b961e644-130e-4e44-8fd9-52f70593a69d)
사용자가  정보 제공에 동의했을 때 기본값 좌표와 다른 값이 출력되는 모습
![Screen Recording 2025-01-08 at 16 27 44](https://github.com/user-attachments/assets/8aed64ef-166a-4610-9ffa-c64626179fa6)
사용자가 정보 제공에 거절했을 때 기본값 좌표가 유지되는 모습

## 💬 공유사항 to 리뷰어
- `CoreLocation`을 사용하여 구현했습니다.
- 아직 다른 객체로 좌표값을 전달할 일이 없기 때문에 `print`만 하도록 구현했습니다.
- 앱이 실행되자마자 `LocationManager`가 초기화되어 사용자에게 요청을 보내야하기 때문에, `rootViewController`에 `LocationManager`의 인스턴스를 생성했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
