### PR TITLE
[Feat] WeatherViewModel, SearchHistoryViewModel

### DIFF
--- a/WhatTheTemp/WhatTheTemp/App/Info.plist
+++ b/WhatTheTemp/WhatTheTemp/App/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>OpenWeatherMapAPIKey</key>
-	<string>8ef68fb1d27fb92f55802750b90d54f7</string>
+	<string>413e75973ebc7b138bd22c9cca05deb3</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>현재 위치의 날씨 정보 제공을 위해서는 위치 정보 수집 동의가 필요합니다.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>

--- a/WhatTheTemp/WhatTheTemp/Model/CityWeather.swift
+++ b/WhatTheTemp/WhatTheTemp/Model/CityWeather.swift
@@ -1,0 +1,18 @@
+//
+//  CityWeather.swift
+//  WhatTheTemp
+//
+//  Created by EMILY on 12/01/2025.
+//
+
+import Foundation
+
+/// SearchHistoryView - collection view와 바인딩할 모델
+struct CityWeather {
+    let weatherCode: Int
+    let cityName: String
+    let weatherDescription: String
+    let currentTemperature: Double
+    let minTemperature: Double
+    let maxTemperature: Double
+}

--- a/WhatTheTemp/WhatTheTemp/Model/Current.swift
+++ b/WhatTheTemp/WhatTheTemp/Model/Current.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// WeatherView - 현재 날씨에 바인딩할 모델
 struct Current {
     let locationName: String = "서울시"
     let weatherDescription: String      // 구름 조금

--- a/WhatTheTemp/WhatTheTemp/Model/WeatherResponse.swift
+++ b/WhatTheTemp/WhatTheTemp/Model/WeatherResponse.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// OpenWeather API 응답 데이터에 대응하는 모델
 struct WeatherResponse: Decodable {
     let currentWeather: CurrentWeather
     let hourlyWeather: [HourlyWeather]

--- a/WhatTheTemp/WhatTheTemp/Model/WeatherResponse.swift
+++ b/WhatTheTemp/WhatTheTemp/Model/WeatherResponse.swift
@@ -32,7 +32,7 @@ struct Weather: Decodable {
 struct CurrentWeather: Decodable {
     let temperature: Double                 // 현재 온도
     let feelsLike: Double                   // 체감 온도
-    let humidity: Int                       // 현재 습도
+    let humidity: Double                       // 현재 습도
     let windSpeed: Double                   // 현재 풍속
     let weather: [Weather]                  // 날씨 코드, 날씨 상태
     
@@ -48,7 +48,7 @@ struct CurrentWeather: Decodable {
 struct HourlyWeather: Decodable {
     let dateTime: Int                        // timeIntervalSince1970 값
     let temperature: Double                 // 시간 별 온도
-    let rain: Int                            // 강수 확률 MARK: current weather에 강수 확률이 없어서 이 값을 현재 강수 확률로 활용해야 할 듯
+    let rain: Double                            // 강수 확률 MARK: current weather에 강수 확률이 없어서 이 값을 현재 강수 확률로 활용해야 할 듯
     let weather: [Weather]                   // 시간 별 날씨 icon에 활용할 날씨 코드
     
     enum CodingKeys: String, CodingKey {

--- a/WhatTheTemp/WhatTheTemp/Model/WeatherSummary.swift
+++ b/WhatTheTemp/WhatTheTemp/Model/WeatherSummary.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// WeatherView - today, tomorrow, next 3 days에 바인딩할 모델
 struct WeatherSummary {
     let time: Date                      // 시간
     let statusCode: Int                 // 날씨 코드

--- a/WhatTheTemp/WhatTheTemp/Network/WeatherRepository.swift
+++ b/WhatTheTemp/WhatTheTemp/Network/WeatherRepository.swift
@@ -12,13 +12,27 @@ import RxSwift
 
 protocol WeatherRepositoryProtocol {
     func fetchWeather(lat: Double, lon: Double) -> Single<WeatherResponse>
+    func fetchWeathers(coordinates: [(lat: Double, lon: Double)]) -> Single<[WeatherResponse]>
 }
 
 final class WeatherRepository: WeatherRepositoryProtocol {
     private let provider = MoyaProvider<WeatherAPI>()
     
+    /// 단일 좌표에 대한 단일 날씨 데이터 반환
     func fetchWeather(lat: Double, lon: Double) -> Single<WeatherResponse> {
         return provider.rx.request(.oneCall(lat: lat, lon: lon))
             .map(WeatherResponse.self)
+    }
+    
+    /// 여러개의 좌표를 배열로 받아 그에 대응하는 날씨 데이터의 배열을 반환
+    func fetchWeathers(coordinates: [(lat: Double, lon: Double)]) -> Single<[WeatherResponse]> {
+        let requests = coordinates.map { (lat, lon) in
+            fetchWeather(lat: lat, lon: lon)
+        }
+        
+        /// zip : 입력 순서와 동일한 순서로 결과를 방출하는 것을 보장
+        return Single.zip(requests) { responses in
+            return responses
+        }
     }
 }

--- a/WhatTheTemp/WhatTheTemp/ViewModel/SearchHistoryViewModel.swift
+++ b/WhatTheTemp/WhatTheTemp/ViewModel/SearchHistoryViewModel.swift
@@ -1,0 +1,45 @@
+//
+//  SearchHistoryViewModel.swift
+//  WhatTheTemp
+//
+//  Created by EMILY on 12/01/2025.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+class SearchHistoryViewModel {
+    private let repository: WeatherRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    
+    let cityWeathers = PublishRelay<[CityWeather]>()
+    
+    init(repository: WeatherRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    func fetchMultipleWeathers(coordinates: [(lat: Double, lon: Double)]) {
+        repository.fetchWeathers(coordinates: coordinates)
+            .map { responses -> [CityWeather] in
+                responses.map { response in
+                    let cityWeather = CityWeather(weatherCode: response.currentWeather.weather[0].code,
+                                                  cityName: "임시값 서울시",
+                                                  weatherDescription: response.currentWeather.weather[0].description,
+                                                  currentTemperature: response.currentWeather.temperature,
+                                                  minTemperature: response.dailyWeather[0].temperature.minTemperature,
+                                                  maxTemperature: response.dailyWeather[0].temperature.maxTemperature)
+                    return cityWeather
+                }
+            }
+            .subscribe(
+                onSuccess: { [weak self] cityWeathers in
+                    self?.cityWeathers.accept(cityWeathers)
+                },
+                onFailure: { error in
+                    print("에러 발생: \(error)")
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+}

--- a/WhatTheTemp/WhatTheTemp/ViewModel/WeatherViewModel.swift
+++ b/WhatTheTemp/WhatTheTemp/ViewModel/WeatherViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  WeatherViewModel.swift
+//  WhatTheTemp
+//
+//  Created by 손겸 on 1/12/25.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+class WeatherViewModel {
+    private let repository: WeatherRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    
+    let currentWeather = PublishRelay<Current>()
+    
+    init(repository: WeatherRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    func fetchWeatherResponse(lat: Double, lon: Double) {
+        repository.fetchWeather(lat: lat, lon: lon)
+            .subscribe(onSuccess: { [weak self] (response: WeatherResponse) in
+                let current = Current(weatherDescription: response.currentWeather.weather[0].description,
+                                      currentTemperature: response.currentWeather.temperature,
+                                      weatherCode: response.currentWeather.weather[0].code,
+                                      feelsLikeTemperature: response.currentWeather.feelsLike,
+                                      minTemperature: response.dailyWeather[0].temperature.minTemperature,
+                                      maxTemperature: response.dailyWeather[0].temperature.maxTemperature,
+                                      windSpeed: response.currentWeather.windSpeed,
+                                      humidity: response.currentWeather.humidity,
+                                      rainProbability: response.hourlyWeather[0].rain)
+                self?.currentWeather.accept(current)
+            }, onFailure: { error in
+                print("에러 발생: \(error)")
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/WhatTheTemp/WhatTheTemp/ViewModel/WeatherViewModel.swift
+++ b/WhatTheTemp/WhatTheTemp/ViewModel/WeatherViewModel.swift
@@ -21,7 +21,7 @@ class WeatherViewModel {
     
     func fetchWeatherResponse(lat: Double, lon: Double) {
         repository.fetchWeather(lat: lat, lon: lon)
-            .subscribe(onSuccess: { [weak self] (response: WeatherResponse) in
+            .map { response -> Current in
                 let current = Current(weatherDescription: response.currentWeather.weather[0].description,
                                       currentTemperature: response.currentWeather.temperature,
                                       weatherCode: response.currentWeather.weather[0].code,
@@ -31,6 +31,9 @@ class WeatherViewModel {
                                       windSpeed: response.currentWeather.windSpeed,
                                       humidity: response.currentWeather.humidity,
                                       rainProbability: response.hourlyWeather[0].rain)
+                return current
+            }
+            .subscribe(onSuccess: { [weak self] current in
                 self?.currentWeather.accept(current)
             }, onFailure: { error in
                 print("에러 발생: \(error)")


### PR DESCRIPTION
## 📝 요약(Summary)
main 화면인 WeatherView의 ViewModel과 SearchHistoryView의 ViewModel을 1차적으로 구현하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
- 팀원들께 계속해서 `MainViewModel`이라는 명칭으로 말씀드렸지만, 저희가 `메인`이라고 통칭했던 화면의 UI를 구현하신 명지님이 `WeatherView`라고 네이밍하신 것을 확인하고 해당 view와 바인딩할 view model이라는 것을 명시하기 위해 `WeatherViewModel`이라고 네이밍 하였습니다. 즉, 메인 뷰 모델이라고 생각하시는 파일이 `WeatherViewModel.swift`라는 점 공유드립니다!
- `WeatherViewModel`은 김손겸, 전지혜 팀원이 일요일에 zep에서 만나 화면공유를 켜고 함께 코딩하였습니다.
- `SearchHistoryViewModel`의 경우 사용자가 검색했던 도시 정보를 배열로 받아 그 순서가 보장된 날씨 배열을 방출해주어야 한다는 점에서 어떻게 해야할지 고민하다가 `zip` operator를 활용하여 구현하게 되었습니다.

### WeatherViewModel 추가 구현 필요사항
- repository가 방출하는 `WeatherResponse` 모델을 `view`와 바인딩하는 데 필요한 프로퍼티만 가진 `Current` 모델로 가공하는 과정을 `subscribe`에서 전부 처리하는 것이 아니라, `map` operator를 활용하도록 리팩토링이 필요합니다.
- today, tomorrow, next 3 days에 필요한 데이터를 방출하는 메소드의 추가 구현이 필요합니다. → 이거까지 완료하지 않았는데 PR을 연 이유 : 우선 이 부분까지만이라도 merge 하면 팀원들이 일부 뷰와의 바인딩 구현을 더 빠르게 시작하실 수 있을 거 같아서 했습니다. 완료한 뒤 merge가 적합하다고 의견이 모아질 경우 수정 commit 한 뒤 merge 하겠습니다! 의견 남겨주세요

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
