### PR TITLE
[Fix] prefetching 활성화로 인한 셀 로드 오류

### DIFF
--- a/WhatTheTemp/WhatTheTemp/App/Info.plist
+++ b/WhatTheTemp/WhatTheTemp/App/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>OpenWeatherMapAPIKey</key>
-	<string>143289c7fb7e07b4b21f8bc8027878b8</string>
+	<string>413e75973ebc7b138bd22c9cca05deb3</string>
 	<key>VisualCrossingAPIKey</key>
 	<string>C3YJ4U9X3D7Q9YDRVBRVEUL5C</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/WhatTheTemp/WhatTheTemp/MainUI/CustomView/HourlyCollectionViewCell.swift
+++ b/WhatTheTemp/WhatTheTemp/MainUI/CustomView/HourlyCollectionViewCell.swift
@@ -75,7 +75,7 @@ final class HourlyCollectionViewCell: UICollectionViewCell {
             .disposed(by: disposeBag)
         
         Observable.just(data)
-            .map { "\($0.temperature)°C" }
+            .map { "\($0.temperature)°" }
             .bind(to: temperatureLabel.rx.text)
             .disposed(by: disposeBag)
         

--- a/WhatTheTemp/WhatTheTemp/MainUI/CustomView/WeatherPageCell.swift
+++ b/WhatTheTemp/WhatTheTemp/MainUI/CustomView/WeatherPageCell.swift
@@ -6,9 +6,11 @@
 //
 
 import UIKit
+import RxSwift
 
 final class WeatherPageCell: UICollectionViewCell {
     private(set) var weatherView = WeatherView()
+    private var disposeBag = DisposeBag()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -17,6 +19,12 @@ final class WeatherPageCell: UICollectionViewCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+        weatherView.resetData()
     }
     
     private func setupWeatherView() {

--- a/WhatTheTemp/WhatTheTemp/MainUI/WeatherView.swift
+++ b/WhatTheTemp/WhatTheTemp/MainUI/WeatherView.swift
@@ -9,7 +9,11 @@ import RxSwift
 
 final class WeatherView: UIView {
     
-    private let disposeBag = DisposeBag()
+    private var disposeBag = DisposeBag()
+    
+    deinit {
+        print(#function)
+    }
     
     private var todatyWeather: [WeatherSummary] = []
     private var tomorrowWeather: [WeatherSummary] = []
@@ -209,6 +213,8 @@ final class WeatherView: UIView {
     
     // MARK: - Binding Method
     func bind(to viewModel: WeatherViewModel) {
+        disposeBag = DisposeBag()
+        
         viewModel.currentWeather
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] current in
@@ -338,5 +344,33 @@ extension UIView {
             label.textColor = color
         }
         subviews.forEach { $0.updateTextColor(to: color) }
+    }
+}
+
+extension WeatherView {
+    func resetData() {
+        // 데이터 초기화
+        todatyWeather = []
+        tomorrowWeather = []
+        nextFiveDaysWeather = []
+        
+        // 상단 UI 초기화
+        locationNameLabel.text = nil
+        weatherLabel.text = nil
+        temperatureLabel.text = nil
+        weatherIconImageView.image = nil
+        
+        // 체감/최저/최고 온도 초기화
+        feelsLikeTemperatureLabel.text = nil
+        minTemperatureLabel.text = nil
+        maxTemperatureLabel.text = nil
+        
+        // 풍속/습도/강수확률 초기화
+        windSpeedLabel.text = nil
+        humidityLabel.text = nil
+        rainLabel.text = nil
+        
+        // 시간별 날씨 CollectionView 초기화
+        hourlyCollectionView.reloadData()
     }
 }

--- a/WhatTheTemp/WhatTheTemp/MainUI/WeatherView.swift
+++ b/WhatTheTemp/WhatTheTemp/MainUI/WeatherView.swift
@@ -258,6 +258,8 @@ final class WeatherView: UIView {
         windSpeedLabel.text = "\(Int(current.windSpeed))m/s"
         humidityLabel.text = "\(current.humidity)%"
         rainLabel.text = "\(Int(current.rainProbability))%"
+        
+        updateTextColor(to: WeatherAssets.getFontColor(from: current.weatherCode))
     }
     
     // 온도단위 업데이트 메서드

--- a/WhatTheTemp/WhatTheTemp/MainUI/WeatherView.swift
+++ b/WhatTheTemp/WhatTheTemp/MainUI/WeatherView.swift
@@ -329,3 +329,12 @@ extension WeatherView: UICollectionViewDataSource {
 // MARK: - UICollectionView Delegate
 extension WeatherView: UICollectionViewDelegate {
 }
+
+extension UIView {
+    func updateTextColor(to color: UIColor) {
+        if let label = self as? UILabel {
+            label.textColor = color
+        }
+        subviews.forEach { $0.updateTextColor(to: color) }
+    }
+}

--- a/WhatTheTemp/WhatTheTemp/MainUI/WeatherViewController.swift
+++ b/WhatTheTemp/WhatTheTemp/MainUI/WeatherViewController.swift
@@ -177,7 +177,6 @@ extension WeatherViewController: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         cell.weatherView.bind(to: viewModel)
-        cell.weatherView.updateTemperatureUnit(isCelsius: isCelsius) // 초기 값 전달
         return cell
     }
 }

--- a/WhatTheTemp/WhatTheTemp/MainUI/WeatherViewController.swift
+++ b/WhatTheTemp/WhatTheTemp/MainUI/WeatherViewController.swift
@@ -15,11 +15,14 @@ final class WeatherViewController: UIViewController {
     private let coreDataManager = SearchCoreDataManager.shared
     private let userDefaults = UserDefaults.standard
     private let lastPageKey = "LastViewedPageIndex"
+    let mainQueue = DispatchQueue.main
     
     private var pages: [SearchHistoryEntity] = [] {
         didSet {
             pageControl.numberOfPages = pages.count + 1
-            pageCollectionView.reloadData()
+            mainQueue.async {
+                self.pageCollectionView.reloadData()
+            }
         }
     }
     
@@ -64,16 +67,16 @@ final class WeatherViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        loadPages()
-        scrollToLastViewedPage()
-        updateTemperatureUnit()
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationBar()
         setupCollectionView()
+        loadPages()
+        scrollToLastViewedPage()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        updateTemperatureUnit()
     }
     
     private func setupCollectionView() {
@@ -173,12 +176,12 @@ final class WeatherViewController: UIViewController {
     }
     
     private func scrollToLastViewedPage() {
-        let lastPageIndex = userDefaults.integer(forKey: lastPageKey)
-        if lastPageIndex < pages.count {
-            let indexPath = IndexPath(item: lastPageIndex, section: 0)
-            pageCollectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
-            pageControl.currentPage = lastPageIndex
+        let lastPageIndex = userDefaults.integer(forKey: lastPageKey) - 1
+        let indexPath = IndexPath(item: lastPageIndex, section: 1)
+        mainQueue.async {
+            self.pageCollectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
         }
+        pageControl.currentPage = lastPageIndex
     }
 }
 
@@ -189,15 +192,33 @@ extension WeatherViewController: UICollectionViewDelegateFlowLayout {
 }
 
 extension WeatherViewController: UICollectionViewDataSource {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 2
+    }
+    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return pages.count + 1
+        if section == 0 { return 1 }
+        else { return pages.count }
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "WeatherPageCell", for: indexPath) as? WeatherPageCell else {
             return UICollectionViewCell()
         }
-        cell.weatherView.bind(to: viewModel)
+        if indexPath.section == 0 {
+//            cell.weatherView.bind(to: viewModel)
+        } else {
+            if pages.isEmpty {
+                cell.weatherView.bind(to: viewModel)
+            }
+            // 코어데이터에 저장된 위치
+            else {
+                // 코어데이터에 저장된 위, 경도 값으로 불러와서 사용해야 함..
+                let storedLocation = pages[indexPath.item]
+                cell.weatherView.bind(to: viewModel)
+                viewModel.fetchMultipleWeathers(entity: storedLocation)
+            }
+        }
         return cell
     }
 }
@@ -206,7 +227,6 @@ extension WeatherViewController: UICollectionViewDelegate {
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         let currentPage = Int(scrollView.contentOffset.x / scrollView.bounds.width)
         pageControl.currentPage = currentPage
-        
         userDefaults.set(currentPage, forKey: lastPageKey)
     }
 }

--- a/WhatTheTemp/WhatTheTemp/ViewModel/WeatherViewModel.swift
+++ b/WhatTheTemp/WhatTheTemp/ViewModel/WeatherViewModel.swift
@@ -84,4 +84,50 @@ class WeatherViewModel {
             })
             .disposed(by: disposeBag)
     }
+    
+    func fetchMultipleWeathers(entity: SearchHistoryEntity) {
+        Observable
+            .combineLatest(Observable.just(entity.cityName ?? ""),
+                           weatherRepository.fetchWeather(lat: entity.lat, lon: entity.lon).asObservable()
+            )
+            .map { (cityName, response) -> (Current, [WeatherSummary], [WeatherSummary], [WeatherSummary]) in
+                let current = Current(locationName: cityName,
+                                      currentTemperature: response.currentWeather.temperature,
+                                      weatherCode: response.currentWeather.weather[0].code,
+                                      feelsLikeTemperature: response.currentWeather.feelsLike,
+                                      minTemperature: response.dailyWeather[0].temperature.minTemperature,
+                                      maxTemperature: response.dailyWeather[0].temperature.maxTemperature,
+                                      windSpeed: response.currentWeather.windSpeed,
+                                      humidity: response.currentWeather.humidity,
+                                      rainProbability: response.hourlyWeather[0].rain)
+                // 현재 "시"
+                let hour = Date.now.hour
+                
+                /// 현재 시 ~ 오늘 23시까지 hourly weather
+                let todayHourly = response.hourlyWeather[0...23-hour].map { hourlyWeather in
+                    WeatherSummary(time: hourlyWeather.dateTime.hour, statusCode: hourlyWeather.weather[0].code, temperature: hourlyWeather.temperature)
+                }
+                
+                /// 내일 0시 ~ 23시까지 hourly weather
+                let tomorrowHourly = response.hourlyWeather[24-hour...47-hour].map { hourlyWeather in
+                    WeatherSummary(time: hourlyWeather.dateTime.hour, statusCode: hourlyWeather.weather[0].code, temperature: hourlyWeather.temperature)
+                }
+                
+                /// 오늘로부터 이틀 뒤 ~ 6일 뒤 (5일 간) daily weather
+                let nextFiveDaily = response.dailyWeather[2...6].map { dailyWeather in
+                    WeatherSummary(time: dailyWeather.dateTime.day, statusCode: dailyWeather.weather[0].code, temperature: dailyWeather.temperature.temperature)
+                }
+                
+                return (current, todayHourly, tomorrowHourly, nextFiveDaily)
+            }
+            .subscribe(onNext: { [weak self] (current, todayHourly, tomorrowHourly, nextFiveDaily) in
+                self?.currentWeather.accept(current)
+                self?.todayHourly.accept(todayHourly)
+                self?.tomorrowHourly.accept(tomorrowHourly)
+                self?.nextFiveDaily.accept(nextFiveDaily)
+            }, onError: { error in
+                print("에러 발생: \(error)")
+            })
+            .disposed(by: disposeBag)
+    }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

1. 문제 현상
컬렉션뷰 셀이 완전히 넘어가기 전 미리 데이터를 prefetching해주는 isPrefetchingEnabled 속성이 있는데, 
이 과정에서 비동기적으로 데이터가 로드되면서 페이지가 넘어가는 중에 이전 셀과 다음 셀에
데이터 바인딩이 중복으로 되는 현상 발생

2. 해결 방법
- isPrefetchingEnabled = false 후, bind에서 disposeBag 초기화.
- 기존 현재 내 위치 날씨 정보를 불러오는 Relay를 코어데이터에 저장된 날씨 정보를 불러올 때도 사용하던 것을 분리.
- Relay 분리에 따른 bind 메서드 분리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

isPrefetchingEnabled 공식 문서 공유합니다!
https://developer.apple.com/documentation/uikit/uicollectionview/isprefetchingenabled

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
